### PR TITLE
Execute transformation in singleton

### DIFF
--- a/lib/roger_autoprefixer.rb
+++ b/lib/roger_autoprefixer.rb
@@ -1,9 +1,6 @@
 module RogerAutoprefixer
 end
 
-# Dependencies
-require "autoprefixer-rails"
-
 # Load modules
 require File.dirname(__FILE__) + "/roger_autoprefixer/middleware"
 require File.dirname(__FILE__) + "/roger_autoprefixer/processor"

--- a/lib/roger_autoprefixer/middleware.rb
+++ b/lib/roger_autoprefixer/middleware.rb
@@ -1,3 +1,4 @@
+require File.dirname(__FILE__) + "/./transformer"
 require "rack/response"
 
 module RogerAutoprefixer
@@ -31,7 +32,7 @@ module RogerAutoprefixer
 
         prefixer_options[:browsers] = @options[:browsers] if @options[:browsers]
 
-        Rack::Response.new(AutoprefixerRails.process(body_str, prefixer_options).css, status, headers).finish
+        Rack::Response.new(Transformer.instance.transform(body_str, prefixer_options), status, headers).finish
       else
         [status, headers, body]
       end

--- a/lib/roger_autoprefixer/transformer.rb
+++ b/lib/roger_autoprefixer/transformer.rb
@@ -1,0 +1,21 @@
+require "singleton"
+require 'autoprefixer-rails'
+
+# The transformer will take care of thread safe transformation of css without
+# vendor prefixes -> css with vendor prefixes using autoprefixer.
+# We need this to prevent deadlock in the V8 engine.
+class Transformer
+  include Singleton
+
+  def initialize
+    @mutex = Mutex.new
+  end
+
+  def transform(code, options)
+    prefixer = nil
+    @mutex.synchronize do
+      prefixer = AutoprefixerRails.process(code, options)
+    end
+    prefixer.css
+  end
+end


### PR DESCRIPTION
Due to deadlock issues put the exectution of autoprefixing
in a singleton. See also https://github.com/DigitPaint/roger_babeljs/commit/eabbeb27c366c6a39e4e55c1c5a0208f73553489
