### PR TITLE
Update therubyracer to mini_racer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 sudo: false
 rvm:
-- 2.0.0
-- 2.1.0
-- 2.2.0
+- 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
-sudo: false
+sudo: required
+dist: trusty
 rvm:
 - 2.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 gemspec
 
 # Add default runtime for ExecJS
-gem "therubyracer"
+gem "mini_racer"
 
 gem "pry"

--- a/lib/roger_autoprefixer/transformer.rb
+++ b/lib/roger_autoprefixer/transformer.rb
@@ -1,7 +1,8 @@
 require "singleton"
+
 # Force ExecJS the engine behind AutoprefixerRails
-# to use therubyracer
-require "therubyracer"
+# to use mini_racer
+require "mini_racer"
 require "autoprefixer-rails"
 
 # The transformer will take care of thread safe transformation of css without

--- a/roger_autoprefixer.gemspec
+++ b/roger_autoprefixer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("roger", [">= 0.11.0"])
   s.add_dependency("autoprefixer-rails", [">= 5.0.0"])
-  s.add_dependency("therubyracer", [">= 0.12"])
+  s.add_dependency("mini_racer", [">= 0.1"])
 
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "test-unit", "~> 3.1.2"

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -19,7 +19,7 @@ module RogerAutoprefixer
 
     def test_middleware_processor
       response = build_stack("flex.css").get("/javascripts/src/test.js")
-      assert response.body.include?("-webkit-flex;")
+      assert response.body.include?("-webkit-box;")
       assert_equal response.status, 200
     end
   end


### PR DESCRIPTION
As therubyracer compiles lib-v8 but on newer systems it turns out that
this is becoming problematic. As `therubyracer` isn't updated for a
while. Currently the mini_racer is a better upated backend for execjs.